### PR TITLE
Assign headers in copy constructor

### DIFF
--- a/Hydra/Http/HttpRequest.cs
+++ b/Hydra/Http/HttpRequest.cs
@@ -97,6 +97,7 @@ namespace Hydra
             Method = other.Method;
             Uri = other.Uri;
             Version = other.Version;
+            Headers = other.Headers;
             Encoding = other.Encoding;
             CancellationToken = other.CancellationToken;
         }


### PR DESCRIPTION
Fixes headers not copied correctly.
(also, sorry, forgot to make new branch)