### PR TITLE
Extend try block for HttpClient

### DIFF
--- a/Hydra/Server.cs
+++ b/Hydra/Server.cs
@@ -245,7 +245,7 @@ namespace Hydra
             }
             finally
             {
-                if(stream != null) await stream.DisposeAsync();
+                if (stream is not null) await stream.DisposeAsync();
                 socket.Shutdown(SocketShutdown.Both);
                 socket.Close();
             }


### PR DESCRIPTION
Avoids silently swallowing exceptions, e.g. those for SSL handshakes or PipeReader/Writer creation