### PR TITLE
Handler Stream Dispose Fix

### DIFF
--- a/Hydra/Http/HttpRequest.cs
+++ b/Hydra/Http/HttpRequest.cs
@@ -163,7 +163,7 @@ namespace Hydra
                     if (distinct.Length != 1 || !int.TryParse(distinct[0], out length)) throw new InvalidContentLengthException();
                 }
 
-                body = new SizedStream(reader.Stream, length);
+                body = new SizedStream(reader.Stream, length, false);
             }
             // if a request has neither Transfer-Encoding nor Content-Length headers it is assumed to have an empty body
             else body = Stream.Null;

--- a/Hydra/SizedStream.cs
+++ b/Hydra/SizedStream.cs
@@ -20,7 +20,7 @@ namespace Hydra
         /// </summary>
         /// <param name="stream">Stream to wrap</param>
         /// <param name="length">Length to limit to</param>
-        internal SizedStream(Stream stream, int length) : base(stream)
+        internal SizedStream(Stream stream, int length, bool ownStream = false) : base(stream, ownStream)
         {
             this.length = length;
         }

--- a/Hydra/SizedStream.cs
+++ b/Hydra/SizedStream.cs
@@ -20,7 +20,7 @@ namespace Hydra
         /// </summary>
         /// <param name="stream">Stream to wrap</param>
         /// <param name="length">Length to limit to</param>
-        internal SizedStream(Stream stream, int length, bool ownStream = false) : base(stream, ownStream)
+        internal SizedStream(Stream stream, int length, bool ownStream) : base(stream, ownStream)
         {
             this.length = length;
         }

--- a/Hydra/WebSocket/WebSocket.cs
+++ b/Hydra/WebSocket/WebSocket.cs
@@ -302,8 +302,7 @@ namespace Hydra
                 currentStream = new WebSocketMaskedStream(
                     new SizedStream(reader.Reader.AsStream(false),
                     (int)frameInfo.Value.Length, true),
-                    frameInfo.Value.MaskingKey,
-                    true);
+                    frameInfo.Value.MaskingKey);
             }
             else if (frameInfo.Value.Opcode is not WebSocketOpcode.Text and not WebSocketOpcode.Binary) throw new NonFrameableMessageFramedException();
             else currentStream = null; // TODO: Fragmented stream

--- a/Hydra/WebSocket/WebSocket.cs
+++ b/Hydra/WebSocket/WebSocket.cs
@@ -301,7 +301,7 @@ namespace Hydra
             {
                 currentStream = new WebSocketMaskedStream(
                     new SizedStream(reader.Reader.AsStream(false),
-                    (int)frameInfo.Value.Length),
+                    (int)frameInfo.Value.Length, true),
                     frameInfo.Value.MaskingKey,
                     true);
             }

--- a/Hydra/WebSocket/WebSocket.cs
+++ b/Hydra/WebSocket/WebSocket.cs
@@ -302,7 +302,8 @@ namespace Hydra
                 currentStream = new WebSocketMaskedStream(
                     new SizedStream(reader.Reader.AsStream(false),
                     (int)frameInfo.Value.Length),
-                    frameInfo.Value.MaskingKey);
+                    frameInfo.Value.MaskingKey,
+                    true);
             }
             else if (frameInfo.Value.Opcode is not WebSocketOpcode.Text and not WebSocketOpcode.Binary) throw new NonFrameableMessageFramedException();
             else currentStream = null; // TODO: Fragmented stream

--- a/Hydra/WebSocket/WebSocketMaskedStream.cs
+++ b/Hydra/WebSocket/WebSocketMaskedStream.cs
@@ -10,7 +10,7 @@ namespace Hydra
     {
         private readonly WebSocketMasker masker;
 
-        internal WebSocketMaskedStream(Stream stream, uint maskingKey, bool ownStream) : base(stream, ownStream)
+        internal WebSocketMaskedStream(Stream stream, uint maskingKey) : base(stream, false)
         {
             masker = new(maskingKey);
         }

--- a/Hydra/WebSocket/WebSocketMaskedStream.cs
+++ b/Hydra/WebSocket/WebSocketMaskedStream.cs
@@ -10,7 +10,7 @@ namespace Hydra
     {
         private readonly WebSocketMasker masker;
 
-        internal WebSocketMaskedStream(Stream stream, uint maskingKey) : base(stream)
+        internal WebSocketMaskedStream(Stream stream, uint maskingKey, bool ownStream) : base(stream, ownStream)
         {
             masker = new(maskingKey);
         }

--- a/Hydra/WrapperStream.cs
+++ b/Hydra/WrapperStream.cs
@@ -10,7 +10,7 @@ namespace Hydra
         private readonly Stream stream;
         private readonly bool ownStream;
 
-        protected WrapperStream(Stream stream, bool ownStream = false)
+        protected WrapperStream(Stream stream, bool ownStream)
         {
             this.stream = stream;
             this.ownStream = ownStream;

--- a/Hydra/WrapperStream.cs
+++ b/Hydra/WrapperStream.cs
@@ -8,10 +8,12 @@ namespace Hydra
     internal abstract class WrapperStream : ReadOnlyStream
     {
         private readonly Stream stream;
+        private readonly bool ownStream;
 
-        protected WrapperStream(Stream stream)
+        protected WrapperStream(Stream stream, bool ownStream = false)
         {
             this.stream = stream;
+            this.ownStream = ownStream;
         }
 
         public override long Length => stream.Length;
@@ -23,7 +25,7 @@ namespace Hydra
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing) stream.Dispose();
+            if (ownStream && disposing) stream.Dispose();
             base.Dispose(disposing);
         }
         public override async ValueTask DisposeAsync()


### PR DESCRIPTION
Previously handlers for HTTP Requests such as BMBF's web server could dispose the NetworkStream used to communicate to the client when say using a ZipStream.

It seems undesirable to have handlers abruptly close the stream used to communicate to the client, even intentionally. Without this, any result error or otherwise would never reach the client and the server would spam exceptions.

This has already been fixed in BMBF 2 by leaving the ZipStream stream open in [MR !13](https://git.bmbf.dev/unicorns/bmbf/-/merge_requests/13).

I applied similar changes to the web socket though those are more questionable and probably redundant.